### PR TITLE
Return to dashboard and logout functionality.

### DIFF
--- a/meal_match/app/assets/stylesheets/application.css
+++ b/meal_match/app/assets/stylesheets/application.css
@@ -8,3 +8,13 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+.flash-alert-text-style {
+  color: red;
+  font-weight: bold; /* equivalent to <strong>Bla</strong> */
+}
+
+.flash-notice-text-style {
+  color: green;
+  font-weight: bold; /* equivalent to <strong>Bla</strong> */
+}

--- a/meal_match/app/controllers/login_controller.rb
+++ b/meal_match/app/controllers/login_controller.rb
@@ -24,5 +24,7 @@ class LoginController < ApplicationController
   def destroy
     # session is a global thing that ruby provides
     session.delete(:user_id)
+    flash[:notice] = "Logged out successfully"
+    redirect_to root_path
   end
 end

--- a/meal_match/app/controllers/recipes_controller.rb
+++ b/meal_match/app/controllers/recipes_controller.rb
@@ -42,4 +42,21 @@ class RecipesController < ApplicationController
       format.json { render json: { recipes: @recipes } }
     end
   end
+
+  # GET /recipes/ingredient_lists/intermediate
+  #
+  # (So that we are not dependent on client side javascript use
+  # for dynamic URI generation based on dropdown selection) A helper
+  # that takes ingredient list id as the query parameter and redirects
+  # to the actual end point for the ingredient search which takes in
+  # the ingredient list id as URI parameter.
+  def search_intermediate
+    ingredient_list_id = params[:ingredient_list_id]
+    if ingredient_list_id.present?
+      redirect_to recipes_search_path(ingredient_list_id)
+    else
+      flash[:alert] = "Please select an ingredient list !"
+      redirect_to dashboard_path
+    end
+  end
 end

--- a/meal_match/app/views/dashboard/show.html.erb
+++ b/meal_match/app/views/dashboard/show.html.erb
@@ -11,7 +11,7 @@
 <!-- local: true set because we want a new page getting loaded on -->
 <!-- form submission and not an AJAX request -->
 <%= form_with id: 'recipe-search-form',
-              url: '#',
+              url: recipes_search_intermediate_path,
               method: :get,
               local: true do %>
   <%= select_tag :ingredient_list_id,
@@ -24,28 +24,4 @@
   <%= submit_tag "Search Recipe", id: "recipe-search-submit" %>
 <% end %>
 
-<script>
-  // Try to generate the action URL when the user clicks on form submission,
-  // using the ingredient list that the user has selected.
-  //
-  // In case no ingredient list is selected, prevent the submission
-  // operation and raise and alert.
-  document.addEventListener("DOMContentLoaded", function() {
-    const form = document.getElementById('recipe-search-form');
-    const dropdown = document.getElementById('ingredient-list-selection-dropdown');
-
-    form.addEventListener('submit', function(event) {
-      const ingredientListId = dropdown.value;
-
-      if (!ingredientListId) {
-        alert("Please select an ingredient list");
-        event.preventDefault();
-        return;
-      }
-
-      // Update the form action dynamically before submission
-      form.action = `/recipes/ingredient_lists/${ingredientListId}`;
-    });
-  });
-</script>
 

--- a/meal_match/app/views/ingredient_lists/index.html.erb
+++ b/meal_match/app/views/ingredient_lists/index.html.erb
@@ -6,21 +6,24 @@
 
 <br/>
 <br/>
-<table border = '1'>
-  <thead>
-    <th>Title</th>
-  </thead>
-  <tbody>
-    <% @ingredient_lists.each do |l| %>
-      <tr>
-        <td> <%= l.title %> </td>
-        <td>
-          <%= button_to "View/Edit", ingredient_list_path(l), method: :get %>
-        </td>
-        <td>
-          <%= button_to "Delete", ingredient_list_path(l), method: :delete %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<!-- Render table only if there is a list -->
+<% if @ingredient_lists.any? %>
+  <table border = '1'>
+    <thead>
+      <th>Title</th>
+    </thead>
+    <tbody>
+      <% @ingredient_lists.each do |l| %>
+        <tr>
+          <td> <%= l.title %> </td>
+          <td>
+            <%= button_to "View/Edit", ingredient_list_path(l), method: :get %>
+          </td>
+          <td>
+            <%= button_to "Delete", ingredient_list_path(l), method: :delete %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/meal_match/app/views/layouts/application.html.erb
+++ b/meal_match/app/views/layouts/application.html.erb
@@ -46,6 +46,18 @@
       <br/>
     <% end %>
 
+    <!-- Display Logout button for all pages except Login -->
+    <% unless current_page?(login_path) %>
+      <!-- By default a button corresponds to post, but we want DELETE -->
+      <!-- so be explicit -->
+      <%= button_to "Log out", logout_path,
+          {
+            id: "logout-btn",
+            method: :delete
+          }%>
+      <br/>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/meal_match/app/views/layouts/application.html.erb
+++ b/meal_match/app/views/layouts/application.html.erb
@@ -23,6 +23,16 @@
   </head>
 
   <body>
+    <!-- If there are flash alerts or notice messages, display them -->
+    <!-- irrespective of the page view (i.e. display for all pages)  -->
+    <% if flash[:notice] %>
+      <p class="flash-notice-text-style"><%= flash[:notice] %></p>
+    <% end %>
+
+    <% if flash[:alert] %>
+      <p class="flash-alert-text-style"><%= flash[:alert] %></p>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/meal_match/app/views/layouts/application.html.erb
+++ b/meal_match/app/views/layouts/application.html.erb
@@ -33,6 +33,19 @@
       <p class="flash-alert-text-style"><%= flash[:alert] %></p>
     <% end %>
 
+    <!-- Display Go back to dashboard for all pages except some (such -->
+    <!-- login and dashboard itself) -->
+    <% unless [dashboard_path, login_path].any? { |p| current_page?(p) } %>
+      <!-- By default a button corresponds to post, but we want get -->
+      <!-- so be explicit -->
+      <%= button_to "Back to Dashboard", dashboard_path,
+          {
+            id: "back-to-dashboard-btn",
+            method: :get
+          }%>
+      <br/>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/meal_match/config/routes.rb
+++ b/meal_match/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
 
   get "/recipes/ingredient_lists/:ingredient_list_id",
       to: "recipes#search",
-      as: :recipes_search_path
+      as: :recipes_search
 
   # Redirect the root path to the login page
   root "login#new"

--- a/meal_match/config/routes.rb
+++ b/meal_match/config/routes.rb
@@ -44,6 +44,13 @@ Rails.application.routes.draw do
 
   resources :ingredient_lists, only: [ :index, :create, :destroy, :show, :update ]
 
+  # This is an intermediate path that takes in ingredient list id as
+  # query parameter and genrates the URL which includes the ingredient list
+  # id as the URI parameter and redirects to recipes_search path
+  get "/recipes/ingredient_lists/intermediate",
+      to: "recipes#search_intermediate",
+      as: :recipes_search_intermediate
+
   get "/recipes/ingredient_lists/:ingredient_list_id",
       to: "recipes#search",
       as: :recipes_search

--- a/meal_match/config/routes.rb
+++ b/meal_match/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
       to: "recipes#search",
       as: :recipes_search
 
-  # Redirect the root path to the login page
-  root "login#new"
+  # Redirect the root path to the dashboard, this will show
+  # the user dashboard if already logged in, or redirect to the logout
+  # if user is not logged in
+  root to: redirect("/dashboard")
 end

--- a/meal_match/spec/requests/flash_test/flash_spec.rb
+++ b/meal_match/spec/requests/flash_test/flash_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Flash", type: :request do
+  let(:user) do
+    User.create!(email: "solidsnake@gmail.com",
+                 first_name: "Solid",
+                 last_name: "Snake")
+  end
+
+  it "should display flash alert messages" do
+    # Try to access dashboard without logging in
+    get "/dashboard"
+    expect(response).to have_http_status(:redirect) # expect a redirect
+
+    # Because we try to access dashboard without login, the above
+    # request should lead to a redirect to the login page
+
+    # The above get request would respond with the
+    # path to redirect to and won't actually redirect,
+    # so we ask explicitly to redirect
+    follow_redirect!
+
+    # The flash alert message for login successful should be visible on the
+    # redirected page
+    expect(response.body).to include("Login Required !")
+  end
+
+  it "should display flash notice messages" do
+    # By pass login
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    # Try to create an ingredient list and successful creation should
+    # lead to a redirect to the index page for the ingredient lists (which
+    # displays all ingredient lists in one place)
+    post "/ingredient_lists"
+    expect(response).to have_http_status(:redirect)
+
+    # The above post request would respond with the
+    # path to redirect to and won't actually redirect,
+    # so we ask explicitly to redirect
+    follow_redirect!
+
+    # The flash notice message for list created successfully should get
+    # displayed on the page
+    expect(response.body).to include("New ingredient list created successfully")
+  end
+end

--- a/meal_match/spec/requests/root_page/root_page_spec.rb
+++ b/meal_match/spec/requests/root_page/root_page_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Root Page", type: :request do
+  let(:user) do
+    User.create!(email: "solidsnake@gmail.com",
+                 first_name: "Solid",
+                 last_name: "Snake")
+  end
+
+  it "redirects the user to the login page if not logged in " do
+    # Root -> dashboard -> login
+    get root_path
+    expect(response).to redirect_to("/dashboard")
+    follow_redirect!
+
+    expect(response).to redirect_to("/login")
+  end
+
+  it "directs the user to the dashboard if already logged in" do
+    # Bypass auth
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    get root_path
+    expect(response).to redirect_to("/dashboard")
+  end
+end

--- a/meal_match/spec/root_spec.rb
+++ b/meal_match/spec/root_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Root route", type: :routing do
-  it "routes / to login#new" do
-    expect(get: "/").to route_to("login#new")
-  end
-end

--- a/meal_match/spec/system/dashboard/back_to_dashboard_button_spec.rb
+++ b/meal_match/spec/system/dashboard/back_to_dashboard_button_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe "Back to dashboard", type: :system do
+  let(:user) do
+    User.create!(email: "solidsnake@gmail.com",
+                 first_name: "Solid",
+                 last_name: "Snake")
+  end
+
+  before do
+    # Bypass authentication
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  # We should not see the "Back to dashboard" button for these
+  # pages
+  #
+  # NOTE: I am deliberately using symbol names here and not
+  # login_path, dashboard_path as that tries to call those methods
+  # when the array is instantiated which we don't want. (In case of some
+  # end points that expect a mandatory URI parameter, that won't even work
+  # due to exceptions getting raised.
+  let(:excluded_paths) { [ :login_path, :dashboard_path ] }
+
+  # We should see the "Back to dashboard" button for these pages, though
+  # this does not include all the paths used by meal match where we should
+  # see the button (everything except excluded paths), it should
+  # suffice
+  #
+  # NOTE: I am deliberately using symbol names here and not
+  # login_path, dashboard_path as that tries to call those methods
+  # when the array is instantiated which we don't want. (In case of some
+  # end points that expect a mandatory URI parameter, that won't even work
+  # due to exceptions getting raised.
+  let(:included_paths) {
+      [
+        # GET /ingredient_lists/ (INDEX page)
+        :ingredient_lists_path,
+
+        # GET /ingredient_lists/:ingredient_list_id
+        :ingredient_list_path,
+
+        # GET /recipes_search/:ingredient_list_id
+        :recipes_search_path
+      ]
+  }
+
+  let(:button_id) { "back-to-dashboard-btn" }
+
+  it "should NOT show the button in case of excluded paths" do
+    excluded_paths.each do |path|
+      visit path
+      expect(page).not_to have_button(id: button_id)
+    end
+  end
+
+  it "should show the button in case of non excluded paths" do
+    ingredient_lst_1 = IngredientList.create!(user: user, title: "List 1")
+
+    included_paths.each do |path|
+      if path == :recipes_search_path
+        # Tries to search recipes corresponding to l1
+        # Below call is equivalent to:
+        # recipes_search_path(ingredient_lst_1)
+        visit send(path, ingredient_lst_1)
+        expect(page).to have_button(id: button_id)
+      elsif path == :ingredient_list_path
+        # GET /ingredient_lists/:ingredient_list_id
+        # ingredient_list_path(ingredient_lst_1)
+        visit send(path, ingredient_lst_1)
+        expect(page).to have_button(id: button_id)
+      else
+        visit send(path)
+        expect(page).to have_button(id: button_id)
+      end
+    end
+  end
+
+  it "clicking the button should take user to the dashboard" do
+    visit ingredient_lists_path
+    expect(page).to have_button(id: button_id)
+    click_button(id: button_id)
+    expect(page).to have_current_path(dashboard_path)
+  end
+end

--- a/meal_match/spec/system/logout/logout_spec.rb
+++ b/meal_match/spec/system/logout/logout_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Logout", type: :system do
+  let(:user) do
+    User.create!(email: "solidsnake@gmail.com",
+                 first_name: "Solid",
+                 last_name: "Snake")
+  end
+
+  before do
+    # Bypass authentication
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  # We should not see the "Logout" button for these
+  # pages
+  #
+  # NOTE: I am deliberately using symbol names here and not
+  # login_path, dashboard_path as that tries to call those methods
+  # when the array is instantiated which we don't want. (In case of some
+  # end points that expect a mandatory URI parameter, that won't even work
+  # due to exceptions getting raised.
+  let(:excluded_paths) { [ :login_path ] }
+
+  # We should see the "Logout" button for these pages, though
+  # this does not include all the paths used by meal match where we should
+  # see the button (everything except excluded paths), it should
+  # suffice
+  #
+  # NOTE: I am deliberately using symbol names here and not
+  # login_path, dashboard_path as that tries to call those methods
+  # when the array is instantiated which we don't want. (In case of some
+  # end points that expect a mandatory URI parameter, that won't even work
+  # due to exceptions getting raised.
+  let(:included_paths) {
+      [
+        # GET /ingredient_lists/ (INDEX page)
+        :ingredient_lists_path,
+
+        # GET /ingredient_lists/:ingredient_list_id
+        :ingredient_list_path,
+
+        # GET /recipes_search/:ingredient_list_id
+        :recipes_search_path
+      ]
+  }
+
+  let(:button_id) { "logout-btn" }
+
+  it "should NOT show the button in case of excluded paths" do
+    excluded_paths.each do |path|
+      visit send(path)
+      expect(page).not_to have_button(id: button_id)
+    end
+  end
+
+  it "should show the button in case of non excluded paths" do
+    ingredient_lst_1 = IngredientList.create!(user: user, title: "List 1")
+
+    included_paths.each do |path|
+      if path == :recipes_search_path
+        # Tries to search recipes corresponding to l1
+        # Below call is equivalent to:
+        # recipes_search_path(ingredient_lst_1)
+        visit send(path, ingredient_lst_1)
+        expect(page).to have_button(id: button_id)
+      elsif path == :ingredient_list_path
+        # GET /ingredient_lists/:ingredient_list_id
+        # ingredient_list_path(ingredient_lst_1)
+        visit send(path, ingredient_lst_1)
+        expect(page).to have_button(id: button_id)
+      else
+        visit send(path)
+        expect(page).to have_button(id: button_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds functionality so that:

1. User is able to go back to dashboard from any page (except dashboard, login)
2. User is able to log out after being logged in.
3. Minor other fixes (like removing javascript from the front end part of my code so that app works without javascript support and fix for a table, i.e. table headers for the index page of ingredient lists should render only when that table has some contents)