### PR TITLE
Add cucumber acceptance tests for my (Eshan) user stories

### DIFF
--- a/meal_match/Gemfile
+++ b/meal_match/Gemfile
@@ -86,6 +86,8 @@ gem "omniauth-google-oauth2" # OAuth specifically for google
 # Don't need rspec for :production environment
 group :development, :test do
   gem "rspec-rails"
+  gem "cucumber-rails"
+  gem "database_cleaner"
 end
 
 # YARD documentation generation

--- a/meal_match/Gemfile.lock
+++ b/meal_match/Gemfile.lock
@@ -130,6 +130,7 @@ GEM
       cucumber (>= 7, < 11)
       railties (>= 6.1, < 9)
     cucumber-tag-expressions (6.1.2)
+    database_cleaner (2.1.0)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
@@ -160,6 +161,7 @@ GEM
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
     fugit (1.11.2)
@@ -507,6 +509,7 @@ DEPENDENCIES
   capybara
   cucumber-rails
   database_cleaner-active_record
+  database_cleaner
   debug
   dotenv-rails
   httparty

--- a/meal_match/Gemfile.lock
+++ b/meal_match/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-arm-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-musl)
@@ -284,6 +286,7 @@ GEM
     pg (1.6.2)
     pg (1.6.2-aarch64-linux)
     pg (1.6.2-aarch64-linux-musl)
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     pg (1.6.2-x86_64-linux-musl)
     pp (0.6.2)
@@ -459,6 +462,7 @@ GEM
     thor (1.4.0)
     thruster (0.1.15)
     thruster (0.1.15-aarch64-linux)
+    thruster (0.1.15-arm64-darwin)
     thruster (0.1.15-x86_64-linux)
     timeout (0.4.3)
     tsort (0.2.0)
@@ -500,6 +504,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin-24
   x86_64-linux-gnu
   x86_64-linux-musl
 
@@ -508,8 +513,8 @@ DEPENDENCIES
   brakeman
   capybara
   cucumber-rails
-  database_cleaner-active_record
   database_cleaner
+  database_cleaner-active_record
   debug
   dotenv-rails
   httparty

--- a/meal_match/app/views/ingredient_lists/index.html.erb
+++ b/meal_match/app/views/ingredient_lists/index.html.erb
@@ -8,7 +8,7 @@
 <br/>
 <!-- Render table only if there is a list -->
 <% if @ingredient_lists.any? %>
-  <table border = '1'>
+  <table border = '1' data-testid="ingredient-lists-table">
     <thead>
       <th>Title</th>
     </thead>

--- a/meal_match/app/views/ingredient_lists/index.html.erb
+++ b/meal_match/app/views/ingredient_lists/index.html.erb
@@ -12,9 +12,9 @@
     <thead>
       <th>Title</th>
     </thead>
-    <tbody>
+    <tbody data-testid = "ingredient-lists-table-body">
       <% @ingredient_lists.each do |l| %>
-        <tr>
+        <tr data-testid = "ingredient-list-<%= l.id %>">
           <td> <%= l.title %> </td>
           <td>
             <%= button_to "View/Edit", ingredient_list_path(l), method: :get %>

--- a/meal_match/features/ingredient_list_create.feature
+++ b/meal_match/features/ingredient_list_create.feature
@@ -1,4 +1,7 @@
 Feature: Create Ingredient List
+  As a logged in user
+  I want to create multiple ingredient lists
+  So I can organize ingredients by meal plans
 
   Scenario: Successful creation of Ingredient List
     Given I am a logged in user

--- a/meal_match/features/ingredient_list_create.feature
+++ b/meal_match/features/ingredient_list_create.feature
@@ -1,0 +1,14 @@
+Feature: Create Ingredient List
+
+  Scenario: Successful creation of Ingredient List
+    Given I am a logged in user
+    And I am on the ingredient lists manager page
+    And I have already created a few ingredient lists
+    When I click to create a new ingredient list
+    Then I should see the newly created ingredient list below the previously created lists
+
+  Scenario: Newly created list should have a default title
+    Given I am a logged in user
+    And I am on the ingredient lists manager page
+    When I click to create a new ingredient list
+    Then I should see the newly created list with the default title "Untitled list"

--- a/meal_match/features/ingredient_list_delete.feature
+++ b/meal_match/features/ingredient_list_delete.feature
@@ -1,4 +1,7 @@
 Feature: Delete Ingredient List
+  As a logged in user
+  I should be able to delete my created ingredient list
+  So that I can keep my ingredient lists organized
 
   Scenario: Successful deletion of ingredient list
     Given I am a logged in user

--- a/meal_match/features/ingredient_list_delete.feature
+++ b/meal_match/features/ingredient_list_delete.feature
@@ -1,0 +1,15 @@
+Feature: Delete Ingredient List
+
+  Scenario: Successful deletion of ingredient list
+    Given I am a logged in user
+    And I have already created an ingredient list titled "List 1"
+    And I am on the ingredient lists manager page
+    When I click to delete the ingredient list titled "List 1"
+    Then I should no longer see the ingredient list titled "List 1" in the ingredient lists table
+
+  Scenario: All lists have been deleted
+    Given I am a logged in user
+    And I have already created a few ingredient lists
+    And I am on the ingredient lists manager page
+    When I click to delete all ingredient lists
+    Then I should not see a table of ingredient lists

--- a/meal_match/features/ingredient_list_save.feature
+++ b/meal_match/features/ingredient_list_save.feature
@@ -1,0 +1,10 @@
+Feature: Created Ingredient list remains saved across user logins
+
+  Scenario: Saved Ingredient List persists between logins
+    Given I am a logged in user
+    And I am on the ingredient lists manager page
+    And I have already created an ingredient list titled "List 1"
+    When I click to log out
+    And I click to sign in with google
+    And I am on the ingredient lists manager page
+    Then I should see the ingredient list titled "List 1"

--- a/meal_match/features/ingredient_list_save.feature
+++ b/meal_match/features/ingredient_list_save.feature
@@ -1,4 +1,7 @@
 Feature: Created Ingredient list remains saved across user logins
+  As a logged in user
+  I want to save ingredient lists against my account
+  So that they persist between logins for reuse.
 
   Scenario: Saved Ingredient List persists between logins
     Given I am a logged in user

--- a/meal_match/features/ingredient_list_select_for_recipe_search.feature
+++ b/meal_match/features/ingredient_list_select_for_recipe_search.feature
@@ -1,4 +1,7 @@
 Feature: Select Ingredient List for recipe search
+  As a logged in user
+  I want to select a saved ingredient list
+  So that I can search for recipes that can be cooked using those ingredients
 
   Scenario: Can select previously created ingredient list for recipe search
     Given I am a logged in user

--- a/meal_match/features/ingredient_list_select_for_recipe_search.feature
+++ b/meal_match/features/ingredient_list_select_for_recipe_search.feature
@@ -1,0 +1,15 @@
+Feature: Select Ingredient List for recipe search
+
+  Scenario: Can select previously created ingredient list for recipe search
+    Given I am a logged in user
+    And I have already created an ingredient list titled "List 1"
+    And I am on the user dashboard page
+    When I select the ingredient list titled "List 1"
+    And I click to search recipes
+    Then I should see the recipes that can be cooked using ingredient list titled "List 1"
+
+  Scenario: Doesn't search for the recipe if no ingredient list is selected
+    Given I am a logged in user
+    And I am on the user dashboard page
+    When I click to search recipes
+    Then I should be asked to select an ingredient list first

--- a/meal_match/features/login.feature
+++ b/meal_match/features/login.feature
@@ -1,4 +1,7 @@
 Feature: Google Login
+  As a user
+  I want to sign in with my Google account
+  So that I can reuse my google account credentials to access the app
 
   Scenario: Successful login with Google Account
     Given I am a non logged in user

--- a/meal_match/features/login.feature
+++ b/meal_match/features/login.feature
@@ -5,3 +5,8 @@ Feature: Google Login
     And I am on the home page
     When I click to sign in with google
     Then I should see the user dashboard
+
+  Scenario: Do not ask for login to already logged in users
+    Given I am a logged in user
+    When I am on the home page
+    Then I should not be asked to sign in with google

--- a/meal_match/features/login.feature
+++ b/meal_match/features/login.feature
@@ -1,0 +1,7 @@
+Feature: Google Login
+
+  Scenario: Successful login with Google Account
+    Given I am a non logged in user
+    And I am on the home page
+    When I click to sign in with google
+    Then I should see the user dashboard

--- a/meal_match/features/logout.feature
+++ b/meal_match/features/logout.feature
@@ -1,4 +1,7 @@
 Feature: Logout from Meal Match
+  As a user
+  I want to sign out from my meal match account
+  So that I can securely leave the app
 
   Scenario: Successful logout from meal match
     Given I am a logged in user

--- a/meal_match/features/logout.feature
+++ b/meal_match/features/logout.feature
@@ -5,3 +5,9 @@ Feature: Logout from Meal Match
     And I am on the home page
     When I click to log out
     Then I should see the login page
+
+  Scenario: Do not ask to logout from the login page
+    Given I am a non logged in user
+    When I am on the home page
+    Then I should see the login page
+    And I should not be asked to logout

--- a/meal_match/features/logout.feature
+++ b/meal_match/features/logout.feature
@@ -1,0 +1,7 @@
+Feature: Logout from Meal Match
+
+  Scenario: Successful logout from meal match
+    Given I am a logged in user
+    And I am on the home page
+    When I click to log out
+    Then I should see the login page

--- a/meal_match/features/return_to_dashboard.feature
+++ b/meal_match/features/return_to_dashboard.feature
@@ -1,4 +1,7 @@
 Feature: Return To Dashboard
+  As a logged in user
+  I want to go back to my user dashboard from any other page within the app
+  So that I can quickly navigate back to my dashboard
 
   Scenario: Directs the user to the dashboard
     Given I am a logged in user

--- a/meal_match/features/return_to_dashboard.feature
+++ b/meal_match/features/return_to_dashboard.feature
@@ -1,0 +1,13 @@
+Feature: Return To Dashboard
+
+  Scenario: Directs the user to the dashboard
+    Given I am a logged in user
+    And I am on the ingredient lists manager page
+    When I click to return to dashboard
+    Then I should see the user dashboard
+
+  Scenario: Do not ask to return to dashboard when already on dashboard
+    Given I am a logged in user
+    When I am on the user dashboard page
+    Then I should not be asked to return to dashboard
+

--- a/meal_match/features/step_definitions/dashboard_steps.rb
+++ b/meal_match/features/step_definitions/dashboard_steps.rb
@@ -1,0 +1,3 @@
+Given("I am on the user dashboard page") do
+  visit dashboard_path
+end

--- a/meal_match/features/step_definitions/dashboard_steps.rb
+++ b/meal_match/features/step_definitions/dashboard_steps.rb
@@ -1,3 +1,18 @@
+SEARCH_RECIPES_BTN_LABEL = "Search Recipe"
+
 Given("I am on the user dashboard page") do
   visit dashboard_path
+end
+
+When("I select the ingredient list titled {string}") do |title|
+  select title, from: "ingredient-list-selection-dropdown"
+end
+
+When("I click to search recipes") do
+  click_button SEARCH_RECIPES_BTN_LABEL
+end
+
+Then("I should be asked to select an ingredient list first") do
+  expect(page).to have_content("Please select an ingredient list !")
+  expect(page).to have_current_path(dashboard_path)
 end

--- a/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
+++ b/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
@@ -93,3 +93,7 @@ Then('I should not see a table of ingredient lists') do
   save_and_open_page
   expect(page).not_to have_css("[data-testid='#{INGREDIENT_LISTS_TABLE_ID}']")
 end
+
+Then("I should see the ingredient list titled {string}") do |title|
+  expect(ingredient_lists_table_row_with_title(title)).not_to be_nil
+end

--- a/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
+++ b/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
@@ -1,3 +1,45 @@
+CREATE_INGREDIENT_LIST_BTN_LABEL = "Create new list"
+
+def ingredient_lists_table_last_row
+  within("[data-testid='ingredient-lists-table-body']") do
+    all("tr").last
+  end
+end
+
 Given("I am on the ingredient lists manager page") do
   visit ingredient_lists_path
+end
+
+Given("I have already created a few ingredient lists") do
+  raise "Expected a logged in user, but was nil !" if @logged_in_user.nil?
+  IngredientList.create!(user: @logged_in_user, title: "Monday Meal Plan")
+  IngredientList.create!(user: @logged_in_user, title: "Tuesday Meal Plan")
+end
+
+When("I click to create a new ingredient list") do
+  click_button CREATE_INGREDIENT_LIST_BTN_LABEL
+end
+
+Then("I should see the newly created ingredient list below the previously created lists") do
+  raise "Expected a logged in user, but was nil !" if @logged_in_user.nil?
+
+  # Most recently created list by the user
+  list_id = @logged_in_user.ingredient_lists.order(created_at: :desc).first.id
+  raise "No ingredient list found for user" if list_id.nil?
+
+  last_row = ingredient_lists_table_last_row
+  expect(last_row["data-testid"]).to eq("ingredient-list-#{list_id}")
+end
+
+Then("I should see the newly created list with the default title {string}") do |default_title|
+  raise "Expected a logged in user, but was nil !" if @logged_in_user.nil?
+
+  list_id = @logged_in_user.ingredient_lists.order(created_at: :desc).first.id
+  raise "No ingredient list found for user" if list_id.nil?
+
+  last_row = ingredient_lists_table_last_row
+  expect(last_row["data-testid"]).to eq("ingredient-list-#{list_id}")
+
+  first_cell = last_row.all("td").first
+  expect(first_cell).to have_content(default_title)
 end

--- a/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
+++ b/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
@@ -1,8 +1,18 @@
 CREATE_INGREDIENT_LIST_BTN_LABEL = "Create new list"
+INGREDIENT_LISTS_TABLE_BODY_ID = "ingredient-lists-table-body"
+DELETE_INGREDIENT_LIST_BTN_LABEL = "Delete"
+TABLE_BODY_CSS = "[data-testid='#{INGREDIENT_LISTS_TABLE_BODY_ID}']"
+INGREDIENT_LISTS_TABLE_ID = "ingredient-lists-table"
 
 def ingredient_lists_table_last_row
-  within("[data-testid='ingredient-lists-table-body']") do
+  within(TABLE_BODY_CSS) do
     all("tr").last
+  end
+end
+
+def ingredient_lists_table_row_with_title(title)
+  within(TABLE_BODY_CSS) do
+    find("tr", text: title)
   end
 end
 
@@ -18,6 +28,11 @@ end
 
 When("I click to create a new ingredient list") do
   click_button CREATE_INGREDIENT_LIST_BTN_LABEL
+end
+
+Given("I have already created an ingredient list titled {string}") do |title|
+  raise "Expected a logged in user, but was nil !" if @logged_in_user.nil?
+  IngredientList.create!(user: @logged_in_user, title: title)
 end
 
 Then("I should see the newly created ingredient list below the previously created lists") do
@@ -42,4 +57,39 @@ Then("I should see the newly created list with the default title {string}") do |
 
   first_cell = last_row.all("td").first
   expect(first_cell).to have_content(default_title)
+end
+
+When("I click to delete the ingredient list titled {string}") do |title|
+  row = ingredient_lists_table_row_with_title(title)
+  row.click_button(DELETE_INGREDIENT_LIST_BTN_LABEL)
+end
+
+Then("I should no longer see the ingredient list titled {string} in the ingredient lists table") do |title|
+  # No table body present if there are 0 lists, hence the check is
+  # necessary before trying to search within table. (When there is no
+  # table, then definitely there is no ingredient list in it, so if
+  # has_css? is false then also we are happy.
+  if has_css?(TABLE_BODY_CSS)
+    within(TABLE_BODY_CSS) do
+      expect(page).not_to have_content(title)
+    end
+  end
+end
+
+When("I click to delete all ingredient lists") do
+  # No table body present if there are 0 lists, hence the check is
+  # necessary before trying to delete each ingredient list.
+  while has_css?(TABLE_BODY_CSS)
+    within(TABLE_BODY_CSS) do
+      # We can't iterate over all rows here and press delete, since
+      # one delete press reloads the page causing the html corresponding to
+      # the other rows we have to be in a stale state, so do it one by one.
+      first("tr").click_button(DELETE_INGREDIENT_LIST_BTN_LABEL)
+    end
+  end
+end
+
+Then('I should not see a table of ingredient lists') do
+  save_and_open_page
+  expect(page).not_to have_css("[data-testid='#{INGREDIENT_LISTS_TABLE_ID}']")
 end

--- a/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
+++ b/meal_match/features/step_definitions/ingredient_lists_manager_steps.rb
@@ -1,0 +1,3 @@
+Given("I am on the ingredient lists manager page") do
+  visit ingredient_lists_path
+end

--- a/meal_match/features/step_definitions/login_logout_steps.rb
+++ b/meal_match/features/step_definitions/login_logout_steps.rb
@@ -22,3 +22,19 @@ Then("I should see the user dashboard") do
   expect(page).to have_current_path(dashboard_path)
   expect(page).to have_content("Dashboard")
 end
+
+Given("I am a logged in user") do
+  step "I am a non logged in user"
+  step "I am on the home page"
+  step "I click to sign in with google"
+  step "I should see the user dashboard"
+end
+
+When("I click to log out") do
+  click_button "Log out"
+end
+
+Then("I should see the login page") do
+  expect(page).to have_current_path(login_path)
+  expect(page).to have_content("Login")
+end

--- a/meal_match/features/step_definitions/login_logout_steps.rb
+++ b/meal_match/features/step_definitions/login_logout_steps.rb
@@ -1,3 +1,6 @@
+LOGIN_BTN_LABEL = "Sign in with Google"
+LOGOUT_BTN_LABEL = "Log out"
+
 Given("I am a non logged in user") do
   # logout request is DELETE /logout not GET /logout
   # so the normal visit logout_path won't work since
@@ -15,7 +18,7 @@ Given("I am on the home page") do
 end
 
 When("I click to sign in with google") do
-  click_button "Sign in with Google"
+  click_button LOGIN_BTN_LABEL
 end
 
 Then("I should see the user dashboard") do
@@ -31,10 +34,18 @@ Given("I am a logged in user") do
 end
 
 When("I click to log out") do
-  click_button "Log out"
+  click_button LOGOUT_BTN_LABEL
 end
 
 Then("I should see the login page") do
   expect(page).to have_current_path(login_path)
   expect(page).to have_content("Login")
+end
+
+Then("I should not be asked to sign in with google") do
+  expect(page).not_to have_button(LOGIN_BTN_LABEL)
+end
+
+Then("I should not be asked to logout") do
+  expect(page).not_to have_button(LOGOUT_BTN_LABEL)
 end

--- a/meal_match/features/step_definitions/login_logout_steps.rb
+++ b/meal_match/features/step_definitions/login_logout_steps.rb
@@ -19,6 +19,11 @@ end
 
 When("I click to sign in with google") do
   click_button LOGIN_BTN_LABEL
+
+  @logged_in_user = User.find_by(email: TEST_USER_EMAIL)
+  if @logged_in_user.nil?
+    raise "Expected logged in user #{TEST_USER_EMAIL} to exist !"
+  end
 end
 
 Then("I should see the user dashboard") do

--- a/meal_match/features/step_definitions/login_steps.rb
+++ b/meal_match/features/step_definitions/login_steps.rb
@@ -1,0 +1,24 @@
+Given("I am a non logged in user") do
+  # logout request is DELETE /logout not GET /logout
+  # so the normal visit logout_path won't work since
+  # it tries to send a GET request.
+  page.driver.submit :delete, '/logout', {}
+  begin
+    page.driver.browser.clear_cookies
+  rescue StandardError => e
+    puts "Could not clear cookies: #{e.message}"
+  end
+end
+
+Given("I am on the home page") do
+  visit root_path
+end
+
+When("I click to sign in with google") do
+  click_button "Sign in with Google"
+end
+
+Then("I should see the user dashboard") do
+  expect(page).to have_current_path(dashboard_path)
+  expect(page).to have_content("Dashboard")
+end

--- a/meal_match/features/step_definitions/recipe_search_steps.rb
+++ b/meal_match/features/step_definitions/recipe_search_steps.rb
@@ -1,0 +1,6 @@
+Then("I should see the recipes that can be cooked using ingredient list titled {string}") do |title|
+  lst = IngredientList.find_by(title: title)
+  expect(lst).not_to be_nil
+
+  expect(page).to have_current_path("/ingredient_list_recipes/#{lst.id}")
+end

--- a/meal_match/features/step_definitions/return_to_dashboard_steps.rb
+++ b/meal_match/features/step_definitions/return_to_dashboard_steps.rb
@@ -1,0 +1,8 @@
+RETURN_TO_DASHBOARD_BTN_LABEL = "Back to Dashboard"
+When("I click to return to dashboard") do
+  click_button RETURN_TO_DASHBOARD_BTN_LABEL
+end
+
+Then("I should not be asked to return to dashboard") do
+  expect(page).not_to have_button(RETURN_TO_DASHBOARD_BTN_LABEL)
+end

--- a/meal_match/features/support/omniauth.rb
+++ b/meal_match/features/support/omniauth.rb
@@ -3,14 +3,18 @@
 # those tests will authenticate via the set mock
 # credentials
 
+TEST_USER_UID = '4204201234'
+TEST_USER_NAME = 'Solid Snake'
+TEST_USER_EMAIL = 'solidsnake@liquid.com'
+
 OmniAuth.config.test_mode = true
 
 OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
   provider: 'google_oauth2',
-  uid: '4204201234',
+  uid: TEST_USER_UID,
   info: {
-    name: 'Solid Snake',
-    email: 'solidsnake@liquid.com'
+    name: TEST_USER_NAME,
+    email: TEST_USER_EMAIL
   },
   credentials: {
     token: 'mock_token',

--- a/meal_match/features/support/omniauth.rb
+++ b/meal_match/features/support/omniauth.rb
@@ -1,0 +1,20 @@
+# Will be only set when the cucumber tests are run
+# due to its location in the folder structure, and
+# those tests will authenticate via the set mock
+# credentials
+
+OmniAuth.config.test_mode = true
+
+OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+  provider: 'google_oauth2',
+  uid: '4204201234',
+  info: {
+    name: 'Solid Snake',
+    email: 'solidsnake@liquid.com'
+  },
+  credentials: {
+    token: 'mock_token',
+    refresh_token: 'mock_refresh_token',
+    expires_at: Time.now + 1.week
+  }
+)


### PR DESCRIPTION
Adding acceptance tests for following user stories I worked on during the project:

**Sprint 1:**
- As a user, I want to sign in with my Google account so I can use the app via my Google Account. (https://github.com/CSCE-606-Project-1/foo1/pull/1)
- As a user, I want to save ingredient lists against my account, so that they persist between logins for reuse. (https://github.com/CSCE-606-Project-1/foo1/pull/7, https://github.com/CSCE-606-Project-1/foo1/pull/14)

**Sprint 2:**
- As a user, I want to create multiple ingredient lists so I can organize by meal plans. (https://github.com/CSCE-606-Project-1/foo1/pull/24)
- As a logged in user, I want to select a saved ingredient list so that I can search for recipes easily. (https://github.com/CSCE-606-Project-1/foo1/pull/24)
- As a user, I should be able to delete my created ingredient list so that I can keep my ingredient lists organized (by deleting outdated and irrelevant ingredient lists) (https://github.com/CSCE-606-Project-1/foo1/pull/24)
- As a user, I want to sign out from Google so I can securely leave the app (https://github.com/CSCE-606-Project-1/foo1/pull/31)
- As a user, I want to go back to my user dashboard from any other page within the app for quick/seamless navigation to my dashboard. (https://github.com/CSCE-606-Project-1/foo1/pull/31)
